### PR TITLE
Add new models to docs

### DIFF
--- a/docs/docs/configuration/detectors.md
+++ b/docs/docs/configuration/detectors.md
@@ -231,6 +231,10 @@ yolov4x-mish-320
 yolov4x-mish-640
 yolov7-tiny-288
 yolov7-tiny-416
+yolov7-640
+yolov7-320
+yolov7x-640
+yolov7x-320
 ```
 
 ### Configuration Parameters


### PR DESCRIPTION
Yolov7-640, Yolov7-320, Yolov7x-640 and Yolov7x-320 models got added to the download_yolo.sh script that gets used as part of generating tensorrt models so they can now be generated